### PR TITLE
Fixed problems with expired tokens from the AuthHandler endpoint

### DIFF
--- a/TokenExchangeAuthenticator/tokenexchangeauthenticator/tests/mocks.py
+++ b/TokenExchangeAuthenticator/tokenexchangeauthenticator/tests/mocks.py
@@ -157,7 +157,7 @@ def setup_oauth_mock(
             'access_token': uuid.uuid4().hex,
             'token_type': token_type,
             'issued_token_type': 'urn:ietf:params:oauth:token-type:access_token',
-            'expires_in': (datetime.now() + timedelta(hours=1)).timestamp()
+            'expires_in': 3600,
         }
 
     def access_token(request):

--- a/TokenExchangeAuthenticator/tokenexchangeauthenticator/tests/test_auth.py
+++ b/TokenExchangeAuthenticator/tokenexchangeauthenticator/tests/test_auth.py
@@ -144,6 +144,7 @@ async def test_authenticator_refresh_token_exchange(get_authenticator, oauth_cli
     class SimpleUser:
         def __init__(self, user_info):
             self.user_info = user_info
+            self.name = user_info['name']
             dt = datetime.now() + timedelta(hours=1)
             user_info['access_token'] = jwt.encode({'exp': dt}, 'secret', algorithm='HS256')
             user_info['refresh_token'] = jwt.encode({'exp': dt}, 'secret', algorithm='HS256')

--- a/TokenExchangeAuthenticator/tokenexchangeauthenticator/tests/test_auth.py
+++ b/TokenExchangeAuthenticator/tokenexchangeauthenticator/tests/test_auth.py
@@ -151,6 +151,7 @@ async def test_authenticator_refresh_token_exchange(get_authenticator, oauth_cli
                 'external-idp-key': {
                     'access_token': 'not-a-jwt-token',
                     # simulate expired exchange token
+                    'expires_in': -100,
                     'exp': int(round(time.time()) - 100)
                 }
             }


### PR DESCRIPTION
Notable changes:

- TokenExchangeAuthenticator now correctly sets the `expires_in` and `exp` parameters based on the token exhange response.
- AuthHandler will force a refresh of the `auth_state`. Thus overriding the `auth_refresh_age` of 300 secs
- Refreshing exchanged tokens will be triggered earlier - when the token expiration har reached the `auth_refresh_age` (instead of 0).